### PR TITLE
Fix Chrome version CI build error on Azure DevOps

### DIFF
--- a/test/AspNetCoreApiSample.IntegrationTests/Resources/SwaggerResourceTest.cs
+++ b/test/AspNetCoreApiSample.IntegrationTests/Resources/SwaggerResourceTest.cs
@@ -14,6 +14,7 @@ namespace Withywoods.AspNetCoreApiSample.IntegrationTests.Resources
     public class SwaggerResourceTest : IClassFixture<LocalServerFactory<Startup>>, IDisposable
     {
         private const string _ResourceEndpoint = "swagger";
+        private const string _ChromeDriverEnvironmentVariableName = "ChromeWebDriver";
 
         private readonly HttpClient _httpClient;
         private readonly RemoteWebDriver _webDriver;
@@ -26,9 +27,11 @@ namespace Withywoods.AspNetCoreApiSample.IntegrationTests.Resources
 
             var chromeOptions = new ChromeOptions();
             chromeOptions.AddArguments("--headless");
-            var executingAssembly = System.Reflection.Assembly.GetExecutingAssembly();
-            var currentLocation = System.IO.Path.GetDirectoryName(executingAssembly.Location);
-            _webDriver = new ChromeDriver(currentLocation, chromeOptions);
+            // chrome driver is sensitive to chrome browser version, CI build should provide the path to driver
+            var chromeDriverLocation = string.IsNullOrEmpty(Environment.GetEnvironmentVariable(_ChromeDriverEnvironmentVariableName)) ?
+                System.IO.Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location) :
+                Environment.GetEnvironmentVariable(_ChromeDriverEnvironmentVariableName);
+            _webDriver = new ChromeDriver(chromeDriverLocation, chromeOptions);
         }
 
         [Fact]


### PR DESCRIPTION
Fix issue devpro/withywoods#9
Change made to look for chrome driver environment variable (needed for web tests with Selenium)
For Azure DevOps the information about the variable name has been found on the documentation: [Vs2019-Server2019-Readme](https://github.com/Microsoft/azure-pipelines-image-generation/blob/master/images/win/Vs2019-Server2019-Readme.md)